### PR TITLE
fix undefined behavior in argument evaluation

### DIFF
--- a/luaaa.hpp
+++ b/luaaa.hpp
@@ -698,7 +698,7 @@ namespace LUAAA_NS
     template<typename TCLASS, bool = std::is_destructible<TCLASS>::value>
     struct DestructorCaller {
         static void Invoke(TCLASS * obj) {
-			obj->~TCLASS();
+            delete obj;
         }
     };
 

--- a/luaaa.hpp
+++ b/luaaa.hpp
@@ -688,8 +688,7 @@ namespace LUAAA_NS
 		template<std::size_t ...Ns>
 		static TCLASS * InvokeImpl(lua_State * state, indices<Ns...>)
         {
-            auto ptr = lua_newuserdata(state, sizeof(TCLASS));
-			return new (ptr) TCLASS(LuaStack<ARGS>::get(state, Ns + 1)...);
+			return new TCLASS(LuaStack<ARGS>::get(state, Ns + 1)...);
         }
     };
 

--- a/luaaa.hpp
+++ b/luaaa.hpp
@@ -730,7 +730,7 @@ namespace LUAAA_NS
 #endif
 
             struct HelperClass {
-                static int f__clsgc(lua_State* state) {
+                static int f__clsgc(lua_State*) {
                     LuaClass<TCLASS>::klassName = nullptr;
                     return 0;
                 }

--- a/luaaa.hpp
+++ b/luaaa.hpp
@@ -721,12 +721,12 @@ namespace LUAAA_NS
 			: m_state(state)
 		{
             assert(state != nullptr);
-            //assert(klassName == nullptr);
+            assert(klassName == nullptr);
 
 #ifndef LUAAA_WITHOUT_CPP_STDLIB
 			luaL_argcheck(state, (klassName == nullptr), 1, (std::string("C++ class `") + RTTI_CLASS_NAME(TCLASS) + "` bind to conflict lua name `" + name + "`, origin name: " + klassName).c_str());
 #else
-            //luaL_argcheck(state, (klassName == nullptr), 1, "C++ class bind to conflict lua class name");
+            luaL_argcheck(state, (klassName == nullptr), 1, "C++ class bind to conflict lua class name");
 #endif
 
             struct HelperClass {


### PR DESCRIPTION
fixes #7

Removes `stackOperatorCaller` by using a second argument pack that generates the index values for each argument.  This means there is no concern about what order the arguments are evaluated in, because the compiler will pair each argument's type `ARGS` with its corresponding index `Ns`.

Based on the method from: https://stackoverflow.com/a/15204752

Depends on #10 