### PR TITLE
Extend example to demonstrate how to pass a LUA function as a std::function to C++

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -153,6 +153,12 @@ public:
         LOG("%s, miaow~~\n", w.c_str());
     }
 
+    void testfunctor(std::function<int(int param)> callback)
+    {
+	int result = callback(42);
+	LOG("Callback with argument 42 leads to %d.\n", result);
+    }
+
 private:
     std::string m_name;
     int m_age;
@@ -331,6 +337,7 @@ void bindToLUA(lua_State * L)
     luaCat.fun("speak", &Cat::speak);
     luaCat.fun("test", &Cat::test);
     luaCat.fun("testSet", testSet);
+    luaCat.fun("testfunctor", &Cat::testfunctor);
     luaCat.fun(std::string("testFunctor1"), [](int n1, int n2) -> int {
         LOG("testFunctor1:%d, %d\n", n1, n2);
         return n1 * n2;

--- a/example/example.lua
+++ b/example/example.lua
@@ -28,6 +28,9 @@ function serialize(obj)
 	return lua  
 end
 
+function luaCallback(param)
+	return param + 1
+end
 
 function testAwesomeCat()
 	local a = AwesomeCat.new ("BINGO")
@@ -45,6 +48,7 @@ function testAwesomeCat()
 	if not WITHOUT_CPP_STDLIB then
 		print(a:testFunctor1(99999, 88888))
 		print(a:testFunctor2(77777, 66666))
+		a:testfunctor(luaCallback)
 	end
 end
 


### PR DESCRIPTION
The std::function works great and it also works bidirectional. I extend the example to demonstrate the usage of a LUA function as std::function.