### PR TITLE
Fix issue with `assert` definition absence.

### DIFF
--- a/luaaa.hpp
+++ b/luaaa.hpp
@@ -41,6 +41,7 @@ inline void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
 #	define USE_NEW_MODULE_REGISTRY 0
 #endif
 
+#include <cassert>
 #include <typeinfo>
 #include <utility>
 


### PR DESCRIPTION
I'm getting following error during compilation:
```
/home/cono/cpp/lua/build/_deps/luaaa-src/luaaa.hpp: In constructor ‘luaaa::LuaClass< <template-parameter-1-1> >::LuaClass(lua_State*, const char*, const luaL_Reg*)’:
/home/cono/cpp/lua/build/_deps/luaaa-src/luaaa.hpp:978:13: error: there are no arguments to ‘assert’ that depend on a template parameter, so a declaration of ‘assert’ must be available [-fpermissive]
  978 |             assert(state != nullptr);
      |             ^~~~~~
/home/cono/cpp/lua/build/_deps/luaaa-src/luaaa.hpp:978:13: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/home/cono/cpp/lua/build/_deps/luaaa-src/luaaa.hpp:979:13: error: there are no arguments to ‘assert’ that depend on a template parameter, so a declaration of ‘assert’ must be available [-fpermissive]
  979 |             assert(klassName == nullptr);
      |             ^~~~~~
```

seems like absence of `#include <cassert>`